### PR TITLE
feat: extend metadata cache with fee and hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tokio",
  "toml",
 ]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ This repository is organised as a Cargo workspace with two crates:
 - `core` – shared models such as the `Holding` struct
 - `aggregator` – canister logic exposing `get_holdings`
 
-The fetcher implementations are mocked and wrapped in small `tokio::time::sleep`
-calls to mimic network latency. Results are cached in-canister for 60&nbsp;s.
+Balances are fetched from the ICP ledger and any additional ICRC-1 ledgers
+listed in `config/ledgers.toml`. Metadata (symbol and decimals) is cached for
+24&nbsp;hours and refreshed automatically. Results are cached in-canister for
+60&nbsp;s.
 
 ## Building
 
@@ -19,6 +21,19 @@ cargo build --quiet
 ```bash
 cargo test --quiet --all
 ```
+
+## Ledger configuration
+
+The file `config/ledgers.toml` lists all ICRC-1 ledger canisters that should be
+queried. Each entry maps a human name to its canister ID:
+
+```toml
+[ledgers]
+ICP = "rwlgt-iiaaa-aaaaa-aaaaa-cai"
+```
+
+Use the `LEDGER_URL` environment variable to override the replica URL when
+running locally.
 
 ## Deployment
 

--- a/src/aggregator/Cargo.toml
+++ b/src/aggregator/Cargo.toml
@@ -18,6 +18,7 @@ toml = "0.8"
 num-bigint = "0.4"
 num-traits = "0.2"
 num-integer = "0.1"
+sha2 = "0.10"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }

--- a/src/aggregator/src/ledger_fetcher.rs
+++ b/src/aggregator/src/ledger_fetcher.rs
@@ -1,10 +1,12 @@
 use bx_core::Holding;
-use candid::{Nat, Principal, Encode, Decode};
-use once_cell::sync::Lazy;
-use serde::Deserialize;
+use candid::{Decode, Encode, Nat, Principal};
 use dashmap::DashMap;
 use futures::future::join_all;
 use num_traits::cast::ToPrimitive;
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::future::Future;
 
 #[cfg(not(target_arch = "wasm32"))]
 use ic_agent::Agent;
@@ -17,18 +19,53 @@ fn now() -> u64 {
         .as_nanos() as u64
 }
 #[cfg(target_arch = "wasm32")]
-fn now() -> u64 { ic_cdk::api::time() }
+fn now() -> u64 {
+    ic_cdk::api::time()
+}
 
 #[derive(Deserialize)]
-struct LedgersConfig { ledgers: std::collections::HashMap<String, String> }
+struct LedgersConfig {
+    ledgers: std::collections::HashMap<String, String>,
+}
 
 static LEDGERS: Lazy<Vec<Principal>> = Lazy::new(|| {
-    let cfg: LedgersConfig = toml::from_str(include_str!("../../../config/ledgers.toml")).expect("invalid config");
-    cfg.ledgers.values().map(|id| Principal::from_text(id).expect("invalid principal")).collect()
+    let cfg: LedgersConfig =
+        toml::from_str(include_str!("../../../config/ledgers.toml")).expect("invalid config");
+    cfg.ledgers
+        .values()
+        .map(|id| Principal::from_text(id).expect("invalid principal"))
+        .collect()
 });
 
-struct Meta { symbol: String, decimals: u8, expires: u64 }
+#[derive(Clone)]
+struct Meta {
+    symbol: String,
+    decimals: u8,
+    fee: u64,
+    hash: [u8; 32],
+    expires: u64,
+}
 static META_CACHE: Lazy<DashMap<Principal, Meta>> = Lazy::new(DashMap::new);
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn with_retry<F, Fut, T>(mut f: F) -> Result<T, ic_agent::AgentError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, ic_agent::AgentError>>,
+{
+    let mut delay = 100u64;
+    for attempt in 0..3 {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(_e) if attempt < 2 => {
+                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                delay *= 2;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!()
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 async fn get_agent() -> Agent {
@@ -39,18 +76,37 @@ async fn get_agent() -> Agent {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn icrc1_metadata(agent: &Agent, canister_id: Principal) -> Result<Vec<(String, candid::types::value::IDLValue)>, ic_agent::AgentError> {
+async fn icrc1_metadata(
+    agent: &Agent,
+    canister_id: Principal,
+) -> Result<Vec<(String, candid::types::value::IDLValue)>, ic_agent::AgentError> {
     let arg = candid::Encode!().unwrap();
-    let bytes = agent.query(&canister_id, "icrc1_metadata").with_arg(arg).call().await?;
-    let res: Vec<(String, candid::types::value::IDLValue)> = candid::Decode!(&bytes, Vec<(String, candid::types::value::IDLValue)>).unwrap();
+    let bytes = agent
+        .query(&canister_id, "icrc1_metadata")
+        .with_arg(arg)
+        .call()
+        .await?;
+    let res: Vec<(String, candid::types::value::IDLValue)> =
+        candid::Decode!(&bytes, Vec<(String, candid::types::value::IDLValue)>).unwrap();
     Ok(res)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn icrc1_balance_of(agent: &Agent, canister_id: Principal, owner: Principal) -> Result<Nat, ic_agent::AgentError> {
+async fn icrc1_balance_of(
+    agent: &Agent,
+    canister_id: Principal,
+    owner: Principal,
+) -> Result<Nat, ic_agent::AgentError> {
     #[derive(candid::CandidType)]
-    struct Account { owner: Principal, subaccount: Option<Vec<u8>> }
-    let arg = candid::Encode!(&Account { owner, subaccount: None }).unwrap();
+    struct Account {
+        owner: Principal,
+        subaccount: Option<Vec<u8>>,
+    }
+    let arg = candid::Encode!(&Account {
+        owner,
+        subaccount: None
+    })
+    .unwrap();
     let bytes = agent
         .query(&canister_id, "icrc1_balance_of")
         .with_arg(arg)
@@ -66,35 +122,70 @@ pub async fn fetch(principal: Principal) -> Vec<Holding> {
     let futures = LEDGERS.iter().cloned().map(|cid| {
         let agent = agent.clone();
         async move {
-        let (symbol, decimals) = match fetch_metadata(&agent, cid).await {
-            Ok(v) => v,
-            Err(_) => return Holding { source: "ledger".into(), token: "unknown".into(), amount: "0".into(), status: "error".into() },
-        };
-        match icrc1_balance_of(&agent, cid, principal).await {
-            Ok(nat) => Holding {
-                source: "ledger".into(),
-                token: symbol,
-                amount: format_amount(nat, decimals),
-                status: "liquid".into(),
-            },
-            Err(_) => Holding { source: "ledger".into(), token: symbol, amount: "0".into(), status: "error".into() },
+            let (symbol, decimals, _) = match fetch_metadata(&agent, cid).await {
+                Ok(v) => v,
+                Err(_) => {
+                    return Holding {
+                        source: "ledger".into(),
+                        token: "unknown".into(),
+                        amount: "0".into(),
+                        status: "error".into(),
+                    }
+                }
+            };
+            match with_retry(|| icrc1_balance_of(&agent, cid, principal)).await {
+                Ok(nat) => Holding {
+                    source: "ledger".into(),
+                    token: symbol,
+                    amount: format_amount(nat, decimals),
+                    status: "liquid".into(),
+                },
+                Err(_) => Holding {
+                    source: "ledger".into(),
+                    token: symbol,
+                    amount: "0".into(),
+                    status: "error".into(),
+                },
+            }
         }
-    }
     });
     join_all(futures).await
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn fetch(_principal: Principal) -> Vec<Holding> { Vec::new() }
+pub async fn fetch(_principal: Principal) -> Vec<Holding> {
+    Vec::new()
+}
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn fetch_metadata(agent: &Agent, cid: Principal) -> Result<(String, u8), ic_agent::AgentError> {
+async fn fetch_metadata(
+    agent: &Agent,
+    cid: Principal,
+) -> Result<(String, u8, u64), ic_agent::AgentError> {
     if let Some(meta) = META_CACHE.get(&cid) {
-        if meta.expires > now() { return Ok((meta.symbol.clone(), meta.decimals)); }
+        if meta.expires > now() {
+            return Ok((meta.symbol.clone(), meta.decimals, meta.fee));
+        }
     }
-    let items = icrc1_metadata(agent, cid).await?;
+    let items = with_retry(|| icrc1_metadata(agent, cid)).await?;
+    let encoded = Encode!(&items).unwrap();
+    let hash: [u8; 32] = Sha256::digest(&encoded).into();
+    if let Some(meta) = META_CACHE.get(&cid) {
+        if meta.hash == hash {
+            META_CACHE.insert(
+                cid,
+                Meta {
+                    hash,
+                    expires: now() + 86_400_000_000_000,
+                    ..meta.clone()
+                },
+            );
+            return Ok((meta.symbol.clone(), meta.decimals, meta.fee));
+        }
+    }
     let mut symbol = String::new();
     let mut decimals: u8 = 0;
+    let mut fee: u64 = 0;
     for (k, v) in items {
         use candid::types::value::IDLValue::*;
         match (k.as_str(), v) {
@@ -104,11 +195,25 @@ async fn fetch_metadata(agent: &Agent, cid: Principal) -> Result<(String, u8), i
             ("icrc1:decimals", Nat64(n)) => decimals = n as u8,
             ("icrc1:decimals", Nat16(n)) => decimals = n as u8,
             ("icrc1:decimals", Nat8(n)) => decimals = n,
+            ("icrc1:fee", Nat(n)) => fee = n.0.to_u64().unwrap_or(0),
+            ("icrc1:fee", Nat32(n)) => fee = n as u64,
+            ("icrc1:fee", Nat64(n)) => fee = n,
+            ("icrc1:fee", Nat16(n)) => fee = n as u64,
+            ("icrc1:fee", Nat8(n)) => fee = n as u64,
             _ => {}
         }
     }
-    META_CACHE.insert(cid, Meta { symbol: symbol.clone(), decimals, expires: now() + 86_400_000_000_000 });
-    Ok((symbol, decimals))
+    META_CACHE.insert(
+        cid,
+        Meta {
+            symbol: symbol.clone(),
+            decimals,
+            fee,
+            hash,
+            expires: now() + 86_400_000_000_000,
+        },
+    );
+    Ok((symbol, decimals, fee))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -118,6 +223,12 @@ fn format_amount(nat: Nat, decimals: u8) -> String {
     let div = BigUint::from(10u32).pow(decimals as u32);
     let (q, r) = nat.0.div_rem(&div);
     let mut frac = r.to_str_radix(10);
-    while frac.len() < decimals as usize { frac.insert(0, '0'); }
-    if decimals == 0 { q.to_str_radix(10) } else { format!("{}.{frac}", q.to_str_radix(10)) }
+    while frac.len() < decimals as usize {
+        frac.insert(0, '0');
+    }
+    if decimals == 0 {
+        q.to_str_radix(10)
+    } else {
+        format!("{}.{frac}", q.to_str_radix(10))
+    }
 }


### PR DESCRIPTION
## Summary
- store token fee and a metadata hash in the ledger metadata cache
- invalidate cached entries when the metadata hash changes
- add sha2 dependency for hashing

## Testing
- `cargo test --quiet --all`
- `cargo check --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686871ab3bbc833383bca15e5bf9b113