### PR TITLE
Add metadata caching and sha2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tokio",
  "toml",
 ]

--- a/src/aggregator/Cargo.toml
+++ b/src/aggregator/Cargo.toml
@@ -18,6 +18,7 @@ toml = "0.8"
 num-bigint = "0.4"
 num-traits = "0.2"
 num-integer = "0.1"
+sha2 = "0.10"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }

--- a/src/aggregator/src/ledger_fetcher.rs
+++ b/src/aggregator/src/ledger_fetcher.rs
@@ -1,11 +1,16 @@
 use bx_core::Holding;
-use candid::{Nat, Principal, Encode, Decode};
-use once_cell::sync::Lazy;
-use serde::Deserialize;
+use candid::{Decode, Encode, Nat, Principal};
 use dashmap::DashMap;
 use futures::future::join_all;
-use std::future::Future;
 use num_traits::cast::ToPrimitive;
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::future::Future;
+
+// Metadata for each ledger is cached with an expiry and a stable hash.
+// When a hash mismatch is detected, the entry is replaced so callers
+// always see the latest token symbol, decimals, and transfer fee.
 
 #[cfg(not(target_arch = "wasm32"))]
 use ic_agent::Agent;
@@ -18,17 +23,32 @@ fn now() -> u64 {
         .as_nanos() as u64
 }
 #[cfg(target_arch = "wasm32")]
-fn now() -> u64 { ic_cdk::api::time() }
+fn now() -> u64 {
+    ic_cdk::api::time()
+}
 
 #[derive(Deserialize)]
-struct LedgersConfig { ledgers: std::collections::HashMap<String, String> }
+struct LedgersConfig {
+    ledgers: std::collections::HashMap<String, String>,
+}
 
 static LEDGERS: Lazy<Vec<Principal>> = Lazy::new(|| {
-    let cfg: LedgersConfig = toml::from_str(include_str!("../../../config/ledgers.toml")).expect("invalid config");
-    cfg.ledgers.values().map(|id| Principal::from_text(id).expect("invalid principal")).collect()
+    let cfg: LedgersConfig =
+        toml::from_str(include_str!("../../../config/ledgers.toml")).expect("invalid config");
+    cfg.ledgers
+        .values()
+        .map(|id| Principal::from_text(id).expect("invalid principal"))
+        .collect()
 });
 
-struct Meta { symbol: String, decimals: u8, expires: u64 }
+#[derive(Clone)]
+struct Meta {
+    symbol: String,
+    decimals: u8,
+    fee: u64,
+    hash: [u8; 32],
+    expires: u64,
+}
 static META_CACHE: Lazy<DashMap<Principal, Meta>> = Lazy::new(DashMap::new);
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -87,36 +107,68 @@ pub async fn fetch(principal: Principal) -> Vec<Holding> {
     let futures = LEDGERS.iter().cloned().map(|cid| {
         let agent = agent.clone();
         async move {
-        let (symbol, decimals) = match fetch_metadata(&agent, cid).await {
-            Ok(v) => v,
-            Err(_) =>
-                return Holding { source: "ledger".into(), token: "unknown".into(), amount: "0".into(), status: "error".into() },
-        };
-        match with_retry(|| icrc1_balance_of(&agent, cid, principal)).await {
-            Ok(nat) => Holding {
-                source: "ledger".into(),
-                token: symbol,
-                amount: format_amount(nat, decimals),
-                status: "liquid".into(),
-            },
-            Err(_) => Holding { source: "ledger".into(), token: symbol, amount: "0".into(), status: "error".into() },
+            let (symbol, decimals, _) = match fetch_metadata(&agent, cid).await {
+                Ok(v) => v,
+                Err(_) => {
+                    return Holding {
+                        source: "ledger".into(),
+                        token: "unknown".into(),
+                        amount: "0".into(),
+                        status: "error".into(),
+                    }
+                }
+            };
+            match with_retry(|| icrc1_balance_of(&agent, cid, principal)).await {
+                Ok(nat) => Holding {
+                    source: "ledger".into(),
+                    token: symbol,
+                    amount: format_amount(nat, decimals),
+                    status: "liquid".into(),
+                },
+                Err(_) => Holding {
+                    source: "ledger".into(),
+                    token: symbol,
+                    amount: "0".into(),
+                    status: "error".into(),
+                },
+            }
         }
-    }
     });
     join_all(futures).await
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn fetch(_principal: Principal) -> Vec<Holding> { Vec::new() }
+pub async fn fetch(_principal: Principal) -> Vec<Holding> {
+    Vec::new()
+}
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn fetch_metadata(agent: &Agent, cid: Principal) -> Result<(String, u8), ic_agent::AgentError> {
+async fn fetch_metadata(
+    agent: &Agent,
+    cid: Principal,
+) -> Result<(String, u8, u64), ic_agent::AgentError> {
     if let Some(meta) = META_CACHE.get(&cid) {
-        if meta.expires > now() { return Ok((meta.symbol.clone(), meta.decimals)); }
+        if meta.expires > now() { return Ok((meta.symbol.clone(), meta.decimals, meta.fee)); }
     }
     let items = with_retry(|| icrc1_metadata(agent, cid)).await?;
+    let encoded = Encode!(&items).unwrap();
+    let hash: [u8; 32] = Sha256::digest(&encoded).into();
+    if let Some(meta) = META_CACHE.get(&cid) {
+        if meta.hash == hash {
+            META_CACHE.insert(
+                cid,
+                Meta {
+                    hash,
+                    expires: now() + 86_400_000_000_000,
+                    ..meta.clone()
+                },
+            );
+            return Ok((meta.symbol.clone(), meta.decimals, meta.fee));
+        }
+    }
     let mut symbol = String::new();
     let mut decimals: u8 = 0;
+    let mut fee: u64 = 0;
     for (k, v) in items {
         use candid::types::value::IDLValue::*;
         match (k.as_str(), v) {
@@ -126,11 +178,25 @@ async fn fetch_metadata(agent: &Agent, cid: Principal) -> Result<(String, u8), i
             ("icrc1:decimals", Nat64(n)) => decimals = n as u8,
             ("icrc1:decimals", Nat16(n)) => decimals = n as u8,
             ("icrc1:decimals", Nat8(n)) => decimals = n,
+            ("icrc1:fee", Nat(n)) => fee = n.0.to_u64().unwrap_or(0),
+            ("icrc1:fee", Nat32(n)) => fee = n as u64,
+            ("icrc1:fee", Nat64(n)) => fee = n,
+            ("icrc1:fee", Nat16(n)) => fee = n as u64,
+            ("icrc1:fee", Nat8(n)) => fee = n as u64,
             _ => {}
         }
     }
-    META_CACHE.insert(cid, Meta { symbol: symbol.clone(), decimals, expires: now() + 86_400_000_000_000 });
-    Ok((symbol, decimals))
+    META_CACHE.insert(
+        cid,
+        Meta {
+            symbol: symbol.clone(),
+            decimals,
+            fee,
+            hash,
+            expires: now() + 86_400_000_000_000,
+        },
+    );
+    Ok((symbol, decimals, fee))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -140,6 +206,12 @@ fn format_amount(nat: Nat, decimals: u8) -> String {
     let div = BigUint::from(10u32).pow(decimals as u32);
     let (q, r) = nat.0.div_rem(&div);
     let mut frac = r.to_str_radix(10);
-    while frac.len() < decimals as usize { frac.insert(0, '0'); }
-    if decimals == 0 { q.to_str_radix(10) } else { format!("{}.{frac}", q.to_str_radix(10)) }
+    while frac.len() < decimals as usize {
+        frac.insert(0, '0');
+    }
+    if decimals == 0 {
+        q.to_str_radix(10)
+    } else {
+        format!("{}.{frac}", q.to_str_radix(10))
+    }
 }


### PR DESCRIPTION
## Summary
- cache ledger metadata using a stable hash
- track ledger `icrc1:fee`
- add `sha2` dependency
- document ledger configuration

## Testing
- `cargo test --quiet --all`
- `cargo clippy --quiet -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6868e4d013788333810f01b16f045f26