### PR TITLE
Add runtime ledger config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ cargo test --quiet --all
 ## Ledger configuration
 
 The file `config/ledgers.toml` lists all ICRC-1 ledger canisters that should be
-queried. Each entry maps a human name to its canister ID:
+queried. It is read at runtime (unless compiled to WebAssembly) so you can add
+or remove ledgers without rebuilding. Set `LEDGERS_FILE` to override the path.
+Each entry under `[ledgers]` maps a human name to its canister ID:
 
 ```toml
 [ledgers]
 ICP = "rwlgt-iiaaa-aaaaa-aaaaa-cai"
+ckBTC = "abcd2-saaaa-aaaaa-aaaaq-cai"
 ```
 
 Use the `LEDGER_URL` environment variable to override the replica URL when

--- a/src/aggregator/Cargo.toml
+++ b/src/aggregator/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 futures = { workspace = true }
-once_cell = "=1.19.0"
+once_cell = { workspace = true }
 bx_core = { path = "../bx_core" }
 dashmap = "5"
 toml = "0.8"


### PR DESCRIPTION
## Summary
- load `config/ledgers.toml` at runtime instead of compile time
- document the ledger configuration format and environment variable in README

## Testing
- `cargo test --quiet --all`
- `cargo clippy --quiet -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6868ed67d5308333a093534fe1817207