### PR TITLE
Log instruction count with ic_cdk::print

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cargo test --quiet --all
 The `get_holdings` query now records the instruction count consumed on every
 call. When invoked for 100 distinct principals on a local replica the average
 was roughly **2.6&nbsp;B** instructions (≈ cycles), comfortably under the 3 B
-budget. The instruction count is printed using `ic_cdk::println!` for each
+budget. The instruction count is printed using `ic_cdk::print` for each
 request so you can verify the cost yourself.
 
 ## Ledger configuration

--- a/src/aggregator/src/lib.rs
+++ b/src/aggregator/src/lib.rs
@@ -41,10 +41,10 @@ pub async fn get_holdings(principal: Principal) -> Vec<Holding> {
         if let Some((cached, ts)) = cache.get(&principal).cloned() {
             if now - ts < 60_000_000_000 {
                 let used = instructions().saturating_sub(start);
-                ic_cdk::println!(
+                ic_cdk::print(format!(
                     "get_holdings took {used} instructions ({:.2} B)",
                     used as f64 / 1_000_000_000f64
-                );
+                ));
                 return cached;
             }
         }
@@ -60,10 +60,10 @@ pub async fn get_holdings(principal: Principal) -> Vec<Holding> {
         cache.insert(principal, (holdings.clone(), now));
     }
     let used = instructions().saturating_sub(start);
-    ic_cdk::println!(
+    ic_cdk::print(format!(
         "get_holdings took {used} instructions ({:.2} B)",
         used as f64 / 1_000_000_000f64
-    );
+    ));
     holdings
 }
 


### PR DESCRIPTION
## Summary
- update the README to mention `ic_cdk::print`
- log instruction counts with `ic_cdk::print` instead of `println!`

## Testing
- `cargo test --quiet --all` *(fails: use of unresolved module or unlinked crate `once_cell`)*
- `cargo clippy --quiet -- -D warnings` *(fails: `cargo-clippy` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869a8e7e6ec833387bb749eb1d507f5