### PR TITLE
Fix lockfile duplicate and address clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Install dfx
       uses: dfinity/setup-dfx@main
+    - name: Prepare dfx identity
+      run: |
+        dfx identity new default --force --storage-mode plaintext >/dev/null 2>&1
+        dfx identity use default
     - name: Run Clippy
       run: cargo clippy --quiet -- -D warnings
     - name: Run Tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,17 +1241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mock_sonic_canister"
-version = "0.1.0"
-dependencies = [
- "candid",
- "ic-cdk",
- "ic-cdk-macros",
- "once_cell",
- "serde",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
   helpful error. The agent is
   initialised once and cloned, avoiding repeated network handshakes
 - Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
-- Common constants like `MINUTE_NS`, `DAY_NS` and `WEEK_NS` centralise refresh durations
+- Common constants like `MINUTE_NS`, `DAY_NS`, `WEEK_NS`, `DAY_SECS` and `WEEK_SECS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating
   the previous fixed delay
 - Wasm builds compile cleanly with no warnings

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 
 - **Height-aware LP cache** with weekly eviction keeps DEX lookups fast
 - **Unified pool registry** refreshed nightly from `data/pools.toml` (embedded on
-  Wasm builds) and exported via the `pools_graphql` endpoint
+  Wasm builds) and exported via the `pools_graphql` endpoint; override the path
+  on native builds via `POOLS_FILE`
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - Adapter fetchers yield to the scheduler before starting requests, eliminating
   the previous fixed delay
 - Wasm builds compile cleanly with no warnings
+- `deploy.sh` spins up a replica using a temporary identity so local tests never
+  leak a mnemonic
 
 ## Building
 
@@ -109,8 +111,6 @@ environment.
 
 1. Install Rust and run `./install_dfx.sh` to install `dfx`, then add the `wasm32-unknown-unknown` target with `rustup target add wasm32-unknown-unknown`.
    Set `DFX_TARBALL` to a pre-downloaded archive to install offline. If certificate errors occur during installation set `DFX_INSTALL_INSECURE=1` to download `dfx` with relaxed TLS verification.
-   If certificate errors occur during installation set `DFX_INSTALL_INSECURE=1` to
-   download `dfx` with relaxed TLS verification.
 2. Run `cargo test --quiet --all` and `cargo clippy --quiet -- -D warnings` before pushing.
    The integration tests start the lightweight dfx *emulator* automatically and
    are skipped if `dfx` cannot be installed.
@@ -118,6 +118,8 @@ environment.
    deployment via `deploy.sh`.
 4. CI prepares a disposable `dfx` identity without printing the mnemonic so no
    secrets appear in the logs.
+5. The `deploy.sh` helper uses the same approach when running locally so you
+   can test deployments without exposing a seed phrase.
 
 ## Further reading
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 ### Key features
 
 - **Height-aware LP cache** with weekly eviction keeps DEX lookups fast
-- **Unified pool registry** refreshed nightly from `data/pools.toml` and
-  exported via the `pools_graphql` endpoint
+- **Unified pool registry** refreshed nightly from `data/pools.toml` (embedded on
+  Wasm builds) and exported via the `pools_graphql` endpoint
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 ### Key features
 
 - **Height-aware LP cache** with weekly eviction keeps DEX lookups fast
-- **Unified pool registry** refreshed nightly from `data/pools.toml` (embedded on
-  Wasm builds via the correct relative path) and exported via the `pools_graphql`
-  endpoint; override the path on native builds via `POOLS_FILE`. For Wasm
-  builds the file is embedded using a compile-time absolute path
+- **Unified pool registry** refreshed nightly from `data/pools.toml` using
+  asynchronous file I/O on native builds (embedded on Wasm builds via the correct
+  relative path) and exported via the `pools_graphql` endpoint; override the path
+  on native builds via `POOLS_FILE`. For Wasm builds the file is embedded using a
+  compile-time absolute path
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ environment.
    are skipped if `dfx` cannot be installed.
 3. On pull requests the GitHub Actions workflow runs tests, clippy, and a test
    deployment via `deploy.sh`.
+4. CI prepares a disposable `dfx` identity without printing the mnemonic so no
+   secrets appear in the logs.
 
 ## Further reading
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
   helper used across adapters and the ledger fetcher, plus utilities for querying
   DEX block height and an `env_principal` helper for configuration. Invalid values
   now print a helpful error. Parsed principals are cached so lookups only happen
-  once. The agent is initialised once and cloned, avoiding repeated network
-  handshakes
+  once. The shared agent logs any root key error and is cloned after the first
+  successful initialisation to avoid repeated network handshakes
 - Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
 - Common constants like `MINUTE_NS`, `DAY_NS`, `WEEK_NS`, `DAY_SECS` and `WEEK_SECS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
   exported via the `pools_graphql` endpoint
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
-- All fetchers run **concurrently** for minimal latency
+- All DEX adapters now fetch **concurrently** via `join_all` for minimal latency
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters
 - Wasm builds compile cleanly with no warnings

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
   helper used across adapters, plus an `env_principal` helper for DEX
   configuration
 - Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
-- Common constants like `DAY_NS` and `WEEK_NS` centralise refresh durations
+- Common constants like `MINUTE_NS`, `DAY_NS` and `WEEK_NS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating
   the previous fixed delay
 - Wasm builds compile cleanly with no warnings

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - The `get_holdings` query runs ledger, neuron, and DEX fetchers concurrently
   for the quickest possible response
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
-  helper used across adapters, plus utilities for querying DEX block height and
-  an `env_principal` helper for configuration. Invalid values now print a
-  helpful error. Parsed principals are cached so lookups only happen once. The
-  agent is initialised once and cloned, avoiding repeated network handshakes
+  helper used across adapters and the ledger fetcher, plus utilities for querying
+  DEX block height and an `env_principal` helper for configuration. Invalid values
+  now print a helpful error. Parsed principals are cached so lookups only happen
+  once. The agent is initialised once and cloned, avoiding repeated network
+  handshakes
 - Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
 - Common constants like `MINUTE_NS`, `DAY_NS`, `WEEK_NS`, `DAY_SECS` and `WEEK_SECS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - Wasm builds compile cleanly with no warnings
 - `deploy.sh` spins up a replica using a temporary identity so local tests never
   leak a mnemonic
+- CI uses the same approach to keep secrets out of the logs
 - Integration tests spawn a lightweight dfx emulator to verify canister
   deployment end-to-end
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
-  helper used across adapters, plus an `env_principal` helper for DEX
-  configuration. Invalid values now print a helpful error. The agent is
+  helper used across adapters, plus utilities for querying DEX block height and
+  an `env_principal` helper for configuration. Invalid values now print a
+  helpful error. The agent is
   initialised once and cloned, avoiding repeated network handshakes
 - Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
 - Common constants like `MINUTE_NS`, `DAY_NS` and `WEEK_NS` centralise refresh durations

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters, plus an `env_principal` helper for DEX
-  configuration
+  configuration. The agent is initialised once and cloned, avoiding repeated
+  network handshakes
 - Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
 - Common constants like `MINUTE_NS`, `DAY_NS` and `WEEK_NS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ environment.
 
 ## Development workflow
 
-1. Install Rust and run `./install_dfx.sh` to install `dfx`, then add the `wasm32-unknown-unknown` target with `rustup target add wasm32-unknown-unknown`.
+1. Install Rust and run `./install_dfx.sh` to install `dfx`. Add the `wasm32-unknown-unknown` target and the `rustfmt` and `clippy` components with:
+   `rustup target add wasm32-unknown-unknown && rustup component add rustfmt clippy`.
    Set `DFX_TARBALL` to a pre-downloaded archive to install offline. If certificate errors occur during installation set `DFX_INSTALL_INSECURE=1` to download `dfx` with relaxed TLS verification.
 2. Run `cargo test --quiet --all` and `cargo clippy --quiet -- -D warnings` before pushing.
    The integration tests start the lightweight dfx *emulator* automatically and

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - Wasm builds compile cleanly with no warnings
 - `deploy.sh` spins up a replica using a temporary identity so local tests never
   leak a mnemonic
+- Integration tests spawn a lightweight dfx emulator to verify canister
+  deployment end-to-end
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - All fetchers run **concurrently** for minimal latency
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters
+- Wasm builds compile cleanly with no warnings
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters, plus an `env_principal` helper for DEX
   configuration
+- Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
 - Common constants like `DAY_NS` and `WEEK_NS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating
   the previous fixed delay

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - **Height-aware LP cache** with weekly eviction keeps DEX lookups fast
 - **Unified pool registry** refreshed nightly from `data/pools.toml` using
   asynchronous file I/O on native builds (embedded on Wasm builds via the correct
-  relative path) and exported via the `pools_graphql` endpoint; override the path
-  on native builds via `POOLS_FILE`. For Wasm builds the file is embedded using a
-  compile-time absolute path
+  relative path) and exported via the `pools_graphql` endpoint. A timer schedules
+  a nightly refresh on both targets; override the path on native builds via
+  `POOLS_FILE`. For Wasm builds the file is embedded using a compile-time
+  absolute path
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency
+- The `get_holdings` query runs ledger, neuron, and DEX fetchers concurrently
+  for the quickest possible response
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters, plus utilities for querying DEX block height and
   an `env_principal` helper for configuration. Invalid values now print a

--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - **Height-aware LP cache** with weekly eviction keeps DEX lookups fast
 - **Unified pool registry** refreshed nightly from `data/pools.toml` (embedded on
   Wasm builds via the correct relative path) and exported via the `pools_graphql`
-  endpoint; override the path on native builds via `POOLS_FILE`
+  endpoint; override the path on native builds via `POOLS_FILE`. For Wasm
+  builds the file is embedded using a compile-time absolute path
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters, plus an `env_principal` helper for DEX
-  configuration. The agent is initialised once and cloned, avoiding repeated
-  network handshakes
+  configuration. Invalid values now print a helpful error. The agent is
+  initialised once and cloned, avoiding repeated network handshakes
 - Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
 - Common constants like `MINUTE_NS`, `DAY_NS` and `WEEK_NS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters
+- Adapter fetchers yield to the scheduler before starting requests, eliminating
+  the previous fixed delay
 - Wasm builds compile cleanly with no warnings
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 
 ### Key features
 
-- **Height-aware LP cache** with weekly eviction keeps DEX lookups fast
+- **Height-aware LP cache** with weekly eviction keeps DEX lookups fast; the eviction timer now runs on both native and Wasm builds
 - **Unified pool registry** refreshed nightly from `data/pools.toml` using
   asynchronous file I/O on native builds (embedded on Wasm builds via the correct
   relative path) and exported via the `pools_graphql` endpoint. A timer schedules

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
 - All fetchers run **concurrently** for minimal latency
+- Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
+  helper used across adapters
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters, plus an `env_principal` helper for DEX
   configuration
+- Common constants like `DAY_NS` and `WEEK_NS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating
   the previous fixed delay
 - Wasm builds compile cleanly with no warnings

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
   helper used across adapters, plus utilities for querying DEX block height and
   an `env_principal` helper for configuration. Invalid values now print a
-  helpful error. The agent is
-  initialised once and cloned, avoiding repeated network handshakes
+  helpful error. Parsed principals are cached so lookups only happen once. The
+  agent is initialised once and cloned, avoiding repeated network handshakes
 - Includes built-in adapters for ICPSwap, Sonic and InfinitySwap
 - Common constants like `MINUTE_NS`, `DAY_NS`, `WEEK_NS`, `DAY_SECS` and `WEEK_SECS` centralise refresh durations
 - Adapter fetchers yield to the scheduler before starting requests, eliminating

--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ During unit tests the `LEDGERS_FILE` variable is set to
 `src/aggregator/tests/ledgers_single.toml`, which references the mock ledger
 canister.
 
+## DEX configuration
+
+Adapters for ICPSwap, Sonic and InfinitySwap locate their canisters via
+environment variables:
+
+- `ICPSWAP_FACTORY` – ICPSwap factory canister ID
+- `SONIC_ROUTER` – Sonic router canister ID
+- `INFINITY_VAULT` – InfinitySwap vault canister ID
+
+When any of these are unset the corresponding adapter simply yields no results.
+Integration tests set them automatically for the local environment.
+
 ## Deployment
 
 The `deploy.sh` script illustrates deployment using `dfx` to a local test network.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency
 - Cross-platform utilities provide a shared `now`, `format_amount` and `get_agent`
-  helper used across adapters
+  helper used across adapters, plus an `env_principal` helper for DEX
+  configuration
 - Adapter fetchers yield to the scheduler before starting requests, eliminating
   the previous fixed delay
 - Wasm builds compile cleanly with no warnings

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Adapters for **ICPSwap**, **Sonic** and **InfinitySwap** live under
 
 - **Height-aware LP cache** with weekly eviction keeps DEX lookups fast
 - **Unified pool registry** refreshed nightly from `data/pools.toml` (embedded on
-  Wasm builds) and exported via the `pools_graphql` endpoint; override the path
-  on native builds via `POOLS_FILE`
+  Wasm builds via the correct relative path) and exported via the `pools_graphql`
+  endpoint; override the path on native builds via `POOLS_FILE`
 - Optional **reward claiming** via `claim_all_rewards` behind the `claim`
   feature flag
 - All DEX adapters now fetch **concurrently** via `join_all` for minimal latency

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,9 @@ set -e
 # Example deployment step using dfx
 # Starts a local replica and deploys the canister so CI can exercise the
 # deployment process without needing access to a remote network.
+# Create a throwaway identity so no mnemonic appears in the logs.
+dfx identity new ci --force --storage-mode plaintext >/dev/null 2>&1 || true
+dfx identity use ci
 dfx start --background --clean
 trap 'dfx stop' EXIT
 dfx deploy

--- a/src/aggregator/src/cache.rs
+++ b/src/aggregator/src/cache.rs
@@ -1,13 +1,12 @@
 use bx_core::Holding;
 use candid::Principal;
+use dashmap::DashMap;
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
-use std::sync::Mutex;
 
-pub type Cache = HashMap<Principal, (Vec<Holding>, u64)>;
+pub type Cache = DashMap<Principal, (Vec<Holding>, u64)>;
 
-static CACHE: Lazy<Mutex<Cache>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static CACHE: Lazy<Cache> = Lazy::new(DashMap::new);
 
-pub fn get_mut() -> std::sync::MutexGuard<'static, Cache> {
-    CACHE.lock().unwrap()
+pub fn get() -> &'static Cache {
+    &CACHE
 }

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -1,4 +1,6 @@
 use super::{DexAdapter, RewardInfo};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::utils::get_agent;
 use crate::{
     lp_cache,
     utils::{format_amount, now},
@@ -46,14 +48,6 @@ struct PoolMetadata {
 
 static META_CACHE: Lazy<DashMap<Principal, (PoolMetadata, u64)>> = Lazy::new(DashMap::new);
 const META_TTL_NS: u64 = 86_400_000_000_000; // 24h
-
-#[cfg(not(target_arch = "wasm32"))]
-async fn get_agent() -> ic_agent::Agent {
-    let url = std::env::var("LEDGER_URL").unwrap_or_else(|_| "http://localhost:4943".into());
-    let agent = ic_agent::Agent::builder().with_url(url).build().unwrap();
-    let _ = agent.fetch_root_key().await;
-    agent
-}
 
 #[async_trait]
 impl DexAdapter for IcpswapAdapter {

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -1,11 +1,11 @@
 use super::{DexAdapter, RewardInfo};
+use crate::lp_cache;
 use async_trait::async_trait;
 use bx_core::Holding;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-use crate::lp_cache;
 
 #[derive(CandidType, Deserialize)]
 struct Token {
@@ -122,7 +122,8 @@ async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
                 });
             }
             temp
-        }).await;
+        })
+        .await;
         out.extend(holdings);
     }
     out
@@ -225,7 +226,10 @@ async fn claim_rewards_impl(principal: Principal) -> Result<u64, String> {
         },
         Err(_) => return Err("factory".into()),
     };
-    let ledger = crate::ledger_fetcher::LEDGERS.get(0).cloned().ok_or("ledger")?;
+    let ledger = crate::ledger_fetcher::LEDGERS
+        .get(0)
+        .cloned()
+        .ok_or("ledger")?;
     let agent = get_agent().await;
     let arg = Encode!().unwrap();
     let bytes = agent
@@ -257,8 +261,8 @@ async fn claim_rewards_impl(principal: Principal) -> Result<u64, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck_macros::quickcheck;
     use once_cell::sync::Lazy;
+    use quickcheck_macros::quickcheck;
     use std::sync::Mutex;
 
     static LAST_QUERY: Lazy<Mutex<Vec<u8>>> = Lazy::new(|| Mutex::new(vec![]));

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -52,7 +52,7 @@ struct PoolMetadata {
 #[cfg(not(target_arch = "wasm32"))]
 static META_CACHE: Lazy<DashMap<Principal, (PoolMetadata, u64)>> = Lazy::new(DashMap::new);
 #[cfg(not(target_arch = "wasm32"))]
-const META_TTL_NS: u64 = 86_400_000_000_000; // 24h
+const META_TTL_NS: u64 = crate::utils::DAY_NS; // 24h
 
 #[async_trait]
 impl DexAdapter for IcpswapAdapter {

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -1,5 +1,8 @@
 use super::{DexAdapter, RewardInfo};
-use crate::lp_cache;
+use crate::{
+    lp_cache,
+    utils::{format_amount, now},
+};
 use async_trait::async_trait;
 use bx_core::Holding;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
@@ -179,36 +182,6 @@ async fn pool_height(agent: &ic_agent::Agent, cid: Principal) -> Option<u64> {
         .await
         .ok()?;
     Decode!(&bytes, u64).ok()
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn format_amount(n: Nat, decimals: u8) -> String {
-    use num_bigint::BigUint;
-    use num_integer::Integer;
-    let div = BigUint::from(10u32).pow(decimals as u32);
-    let (q, r) = n.0.div_rem(&div);
-    let mut frac = r.to_str_radix(10);
-    while frac.len() < decimals as usize {
-        frac.insert(0, '0');
-    }
-    if decimals == 0 {
-        q.to_str_radix(10)
-    } else {
-        format!("{}.{frac}", q.to_str_radix(10))
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64
-}
-
-#[cfg(target_arch = "wasm32")]
-fn now() -> u64 {
-    ic_cdk::api::time()
 }
 
 #[cfg(all(feature = "claim", not(target_arch = "wasm32")))]

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -170,8 +170,6 @@ async fn fetch_meta(agent: &ic_agent::Agent, cid: Principal) -> Option<PoolMetad
     Some(meta)
 }
 
-
-
 #[cfg(all(feature = "claim", not(target_arch = "wasm32")))]
 async fn claim_rewards_impl(principal: Principal) -> Result<u64, String> {
     use crate::cache;

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -74,12 +74,9 @@ pub struct IcpswapAdapter;
 
 #[cfg(not(target_arch = "wasm32"))]
 async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
-    let factory_id = match std::env::var("ICPSWAP_FACTORY") {
-        Ok(v) => match Principal::from_text(v) {
-            Ok(p) => p,
-            Err(_) => return Vec::new(),
-        },
-        Err(_) => return Vec::new(),
+    let factory_id = match crate::utils::env_principal("ICPSWAP_FACTORY") {
+        Some(p) => p,
+        None => return Vec::new(),
     };
     let agent = get_agent().await;
     let arg = Encode!().unwrap();
@@ -186,12 +183,9 @@ async fn pool_height(agent: &ic_agent::Agent, cid: Principal) -> Option<u64> {
 #[cfg(all(feature = "claim", not(target_arch = "wasm32")))]
 async fn claim_rewards_impl(principal: Principal) -> Result<u64, String> {
     use crate::cache;
-    let factory_id = match std::env::var("ICPSWAP_FACTORY") {
-        Ok(v) => match Principal::from_text(v) {
-            Ok(p) => p,
-            Err(_) => return Err("factory".into()),
-        },
-        Err(_) => return Err("factory".into()),
+    let factory_id = match crate::utils::env_principal("ICPSWAP_FACTORY") {
+        Some(p) => p,
+        None => return Err("factory".into()),
     };
     let ledger = crate::ledger_fetcher::LEDGERS
         .first()

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -1,14 +1,17 @@
 use super::{DexAdapter, RewardInfo};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::utils::get_agent;
 use crate::{
     lp_cache,
-    utils::{format_amount, now},
+    utils::{format_amount, get_agent, now},
 };
 use async_trait::async_trait;
 use bx_core::Holding;
-use candid::{CandidType, Decode, Encode, Nat, Principal};
+use candid::{CandidType, Nat, Principal};
+#[cfg(not(target_arch = "wasm32"))]
+use candid::{Decode, Encode};
+#[cfg(not(target_arch = "wasm32"))]
 use dashmap::DashMap;
+#[cfg(not(target_arch = "wasm32"))]
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 
@@ -46,7 +49,9 @@ struct PoolMetadata {
     token1_decimals: u8,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 static META_CACHE: Lazy<DashMap<Principal, (PoolMetadata, u64)>> = Lazy::new(DashMap::new);
+#[cfg(not(target_arch = "wasm32"))]
 const META_TTL_NS: u64 = 86_400_000_000_000; // 24h
 
 #[async_trait]

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -228,11 +228,7 @@ async fn claim_rewards_impl(principal: Principal) -> Result<u64, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use once_cell::sync::Lazy;
     use quickcheck_macros::quickcheck;
-    use std::sync::Mutex;
-
-    static LAST_QUERY: Lazy<Mutex<Vec<u8>>> = Lazy::new(|| Mutex::new(vec![]));
 
     #[tokio::test(flavor = "current_thread")]
     async fn fetch_positions_empty_without_env() {

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -181,11 +181,6 @@ async fn pool_height(agent: &ic_agent::Agent, cid: Principal) -> Option<u64> {
     Decode!(&bytes, u64).ok()
 }
 
-#[cfg(target_arch = "wasm32")]
-async fn pool_height(_agent: &ic_agent::Agent, _cid: Principal) -> Option<u64> {
-    None
-}
-
 #[cfg(not(target_arch = "wasm32"))]
 fn format_amount(n: Nat, decimals: u8) -> String {
     use num_bigint::BigUint;

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -214,8 +214,7 @@ async fn claim_rewards_impl(principal: Principal) -> Result<u64, String> {
     }
     // refresh cache
     let holdings = fetch_positions_impl(principal).await;
-    let mut cache = cache::get_mut();
-    cache.insert(principal, (holdings, now()));
+    cache::get().insert(principal, (holdings, now()));
     Ok(total)
 }
 

--- a/src/aggregator/src/dex/dex_icpswap.rs
+++ b/src/aggregator/src/dex/dex_icpswap.rs
@@ -194,7 +194,7 @@ async fn claim_rewards_impl(principal: Principal) -> Result<u64, String> {
         Err(_) => return Err("factory".into()),
     };
     let ledger = crate::ledger_fetcher::LEDGERS
-        .get(0)
+        .first()
         .cloned()
         .ok_or("ledger")?;
     let agent = get_agent().await;

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -1,4 +1,5 @@
 use super::{DexAdapter, RewardInfo};
+use crate::lp_cache;
 use async_trait::async_trait;
 use bx_core::Holding;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
@@ -6,7 +7,6 @@ use dashmap::DashMap;
 use num_traits::cast::ToPrimitive;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-use crate::lp_cache;
 
 pub struct InfinityAdapter;
 
@@ -84,7 +84,8 @@ async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
             });
         }
         temp
-    }).await;
+    })
+    .await;
     holdings
 }
 
@@ -208,8 +209,8 @@ fn now() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck_macros::quickcheck;
     use candid::Principal;
+    use quickcheck_macros::quickcheck;
 
     #[tokio::test]
     async fn empty_without_env() {

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -1,15 +1,21 @@
 use super::{DexAdapter, RewardInfo};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::utils::get_agent;
 use crate::{
     lp_cache,
-    utils::{format_amount, now},
+    utils::{format_amount, get_agent, now},
 };
 use async_trait::async_trait;
 use bx_core::Holding;
-use candid::{CandidType, Decode, Encode, Nat, Principal};
+#[cfg(not(target_arch = "wasm32"))]
+use candid::Nat;
+use candid::{CandidType, Principal};
+#[cfg(not(target_arch = "wasm32"))]
+use candid::{Decode, Encode};
+#[cfg(not(target_arch = "wasm32"))]
 use dashmap::DashMap;
+#[cfg(not(target_arch = "wasm32"))]
 use num_traits::cast::ToPrimitive;
+#[cfg(not(target_arch = "wasm32"))]
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 
@@ -21,7 +27,9 @@ struct VaultPosition {
     subaccount: Vec<u8>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 static META_CACHE: Lazy<DashMap<Principal, (String, u8, u64)>> = Lazy::new(DashMap::new);
+#[cfg(not(target_arch = "wasm32"))]
 const META_TTL_NS: u64 = 86_400_000_000_000; // 24h
 
 #[async_trait]

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -158,8 +158,6 @@ async fn fetch_meta(agent: &ic_agent::Agent, ledger: Principal) -> Option<(Strin
     Some((symbol, decimals))
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -66,7 +66,9 @@ async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
         Err(_) => return Vec::new(),
     };
     let positions: Vec<VaultPosition> = Decode!(&bytes, Vec<VaultPosition>).unwrap_or_default();
-    let height = pool_height(&agent, vault_id).await.unwrap_or(0);
+    let height = crate::utils::dex_block_height(&agent, vault_id)
+        .await
+        .unwrap_or(0);
     let holdings = lp_cache::get_or_fetch(principal, "infinity", height, || async {
         let mut temp = Vec::new();
         for pos in positions {
@@ -156,17 +158,7 @@ async fn fetch_meta(agent: &ic_agent::Agent, ledger: Principal) -> Option<(Strin
     Some((symbol, decimals))
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-async fn pool_height(agent: &ic_agent::Agent, vault: Principal) -> Option<u64> {
-    let arg = Encode!().unwrap();
-    let bytes = agent
-        .query(&vault, "block_height")
-        .with_arg(arg)
-        .call()
-        .await
-        .ok()?;
-    Decode!(&bytes, u64).ok()
-}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -1,5 +1,8 @@
 use super::{DexAdapter, RewardInfo};
-use crate::lp_cache;
+use crate::{
+    lp_cache,
+    utils::{format_amount, now},
+};
 use async_trait::async_trait;
 use bx_core::Holding;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
@@ -164,41 +167,6 @@ async fn pool_height(agent: &ic_agent::Agent, vault: Principal) -> Option<u64> {
         .await
         .ok()?;
     Decode!(&bytes, u64).ok()
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn format_amount(n: Nat, decimals: u8) -> String {
-    use num_bigint::BigUint;
-    use num_integer::Integer;
-    let div = BigUint::from(10u32).pow(decimals as u32);
-    let (q, r) = n.0.div_rem(&div);
-    let mut frac = r.to_str_radix(10);
-    while frac.len() < decimals as usize {
-        frac.insert(0, '0');
-    }
-    if decimals == 0 {
-        q.to_str_radix(10)
-    } else {
-        format!("{}.{frac}", q.to_str_radix(10))
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn format_amount(n: Nat, _decimals: u8) -> String {
-    n.0.to_string()
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64
-}
-
-#[cfg(target_arch = "wasm32")]
-fn now() -> u64 {
-    ic_cdk::api::time()
 }
 
 #[cfg(test)]

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -1,4 +1,6 @@
 use super::{DexAdapter, RewardInfo};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::utils::get_agent;
 use crate::{
     lp_cache,
     utils::{format_amount, now},
@@ -21,14 +23,6 @@ struct VaultPosition {
 
 static META_CACHE: Lazy<DashMap<Principal, (String, u8, u64)>> = Lazy::new(DashMap::new);
 const META_TTL_NS: u64 = 86_400_000_000_000; // 24h
-
-#[cfg(not(target_arch = "wasm32"))]
-async fn get_agent() -> ic_agent::Agent {
-    let url = std::env::var("LEDGER_URL").unwrap_or_else(|_| "http://localhost:4943".into());
-    let agent = ic_agent::Agent::builder().with_url(url).build().unwrap();
-    let _ = agent.fetch_root_key().await;
-    agent
-}
 
 #[async_trait]
 impl DexAdapter for InfinityAdapter {

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -30,7 +30,7 @@ struct VaultPosition {
 #[cfg(not(target_arch = "wasm32"))]
 static META_CACHE: Lazy<DashMap<Principal, (String, u8, u64)>> = Lazy::new(DashMap::new);
 #[cfg(not(target_arch = "wasm32"))]
-const META_TTL_NS: u64 = 86_400_000_000_000; // 24h
+const META_TTL_NS: u64 = crate::utils::DAY_NS; // 24h
 
 #[async_trait]
 impl DexAdapter for InfinityAdapter {

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -50,12 +50,9 @@ impl DexAdapter for InfinityAdapter {
 
 #[cfg(not(target_arch = "wasm32"))]
 async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
-    let vault_id = match std::env::var("INFINITY_VAULT") {
-        Ok(v) => match Principal::from_text(v) {
-            Ok(p) => p,
-            Err(_) => return Vec::new(),
-        },
-        Err(_) => return Vec::new(),
+    let vault_id = match crate::utils::env_principal("INFINITY_VAULT") {
+        Some(p) => p,
+        None => return Vec::new(),
     };
     let agent = get_agent().await;
     let arg = Encode!(&principal).unwrap();

--- a/src/aggregator/src/dex/dex_infinity.rs
+++ b/src/aggregator/src/dex/dex_infinity.rs
@@ -166,11 +166,6 @@ async fn pool_height(agent: &ic_agent::Agent, vault: Principal) -> Option<u64> {
     Decode!(&bytes, u64).ok()
 }
 
-#[cfg(target_arch = "wasm32")]
-async fn pool_height(_agent: &ic_agent::Agent, _vault: Principal) -> Option<u64> {
-    None
-}
-
 #[cfg(not(target_arch = "wasm32"))]
 fn format_amount(n: Nat, decimals: u8) -> String {
     use num_bigint::BigUint;

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -1,5 +1,7 @@
 use super::{DexAdapter, RewardInfo};
-use crate::lp_cache;
+#[cfg(feature = "claim")]
+use crate::utils::now;
+use crate::{lp_cache, utils::format_amount};
 use async_trait::async_trait;
 use bx_core::Holding;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
@@ -104,39 +106,6 @@ async fn pool_height(agent: &ic_agent::Agent, router: Principal) -> Option<u64> 
 #[cfg(target_arch = "wasm32")]
 async fn fetch_positions_impl(_principal: Principal) -> Vec<Holding> {
     Vec::new()
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn format_amount(n: Nat, decimals: u8) -> String {
-    use num_bigint::BigUint;
-    use num_integer::Integer;
-    let div = BigUint::from(10u32).pow(decimals as u32);
-    let (q, r) = n.0.div_rem(&div);
-    let mut frac = r.to_str_radix(10);
-    while frac.len() < decimals as usize {
-        frac.insert(0, '0');
-    }
-    if decimals == 0 {
-        q.to_str_radix(10)
-    } else {
-        format!("{}.{frac}", q.to_str_radix(10))
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn format_amount(n: Nat, _decimals: u8) -> String {
-    n.0.to_string()
-}
-#[cfg(all(feature = "claim", not(target_arch = "wasm32")))]
-fn now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64
-}
-#[cfg(all(feature = "claim", target_arch = "wasm32"))]
-fn now() -> u64 {
-    ic_cdk::api::time()
 }
 
 #[cfg(all(feature = "claim", not(target_arch = "wasm32")))]

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -121,8 +121,7 @@ async fn claim_impl(principal: Principal) -> Result<u64, String> {
         .map_err(|e| e.to_string())?;
     let spent: u64 = Decode!(&bytes, u64).unwrap_or_default();
     let holdings = fetch_positions_impl(principal).await;
-    let mut cache = cache::get_mut();
-    cache.insert(principal, (holdings, now()));
+    cache::get().insert(principal, (holdings, now()));
     Ok(spent)
 }
 

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -102,11 +102,6 @@ async fn pool_height(agent: &ic_agent::Agent, router: Principal) -> Option<u64> 
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn pool_height(_agent: &ic_agent::Agent, _router: Principal) -> Option<u64> {
-    None
-}
-
-#[cfg(target_arch = "wasm32")]
 async fn fetch_positions_impl(_principal: Principal) -> Vec<Holding> {
     Vec::new()
 }

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -52,7 +52,9 @@ async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
         Err(_) => return Vec::new(),
     };
     let positions: Vec<PositionInfo> = Decode!(&bytes, Vec<PositionInfo>).unwrap_or_default();
-    let height = pool_height(&agent, router_id).await.unwrap_or(0);
+    let height = crate::utils::dex_block_height(&agent, router_id)
+        .await
+        .unwrap_or(0);
     let holdings = lp_cache::get_or_fetch(principal, "sonic", height, || async {
         let mut temp = Vec::new();
         for pos in positions {
@@ -86,17 +88,7 @@ async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
     holdings
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-async fn pool_height(agent: &ic_agent::Agent, router: Principal) -> Option<u64> {
-    let arg = Encode!().unwrap();
-    let bytes = agent
-        .query(&router, "block_height")
-        .with_arg(arg)
-        .call()
-        .await
-        .ok()?;
-    Decode!(&bytes, u64).ok()
-}
+
 
 #[cfg(target_arch = "wasm32")]
 async fn fetch_positions_impl(_principal: Principal) -> Vec<Holding> {

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -1,12 +1,16 @@
 use super::{DexAdapter, RewardInfo};
-#[cfg(not(target_arch = "wasm32"))]
-use crate::utils::get_agent;
 #[cfg(all(feature = "claim", not(target_arch = "wasm32")))]
 use crate::utils::now;
-use crate::{lp_cache, utils::format_amount};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::{
+    lp_cache,
+    utils::{format_amount, get_agent},
+};
 use async_trait::async_trait;
 use bx_core::Holding;
-use candid::{CandidType, Decode, Encode, Nat, Principal};
+use candid::{CandidType, Nat, Principal};
+#[cfg(not(target_arch = "wasm32"))]
+use candid::{Decode, Encode};
 use serde::Deserialize;
 
 #[derive(CandidType, Deserialize, Clone)]

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -116,7 +116,7 @@ async fn claim_impl(principal: Principal) -> Result<u64, String> {
         },
         Err(_) => return Err("router".into()),
     };
-    let ledger = LEDGERS.get(0).cloned().ok_or("ledger")?;
+    let ledger = LEDGERS.first().cloned().ok_or("ledger")?;
     let agent = get_agent().await;
     let arg = Encode!(&principal, &ledger).unwrap();
     let bytes = agent

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -1,5 +1,7 @@
 use super::{DexAdapter, RewardInfo};
-#[cfg(feature = "claim")]
+#[cfg(not(target_arch = "wasm32"))]
+use crate::utils::get_agent;
+#[cfg(all(feature = "claim", not(target_arch = "wasm32")))]
 use crate::utils::now;
 use crate::{lp_cache, utils::format_amount};
 use async_trait::async_trait;
@@ -27,14 +29,6 @@ struct PositionInfo {
 }
 
 pub struct SonicAdapter;
-
-#[cfg(not(target_arch = "wasm32"))]
-async fn get_agent() -> ic_agent::Agent {
-    let url = std::env::var("LEDGER_URL").unwrap_or_else(|_| "http://localhost:4943".into());
-    let agent = ic_agent::Agent::builder().with_url(url).build().unwrap();
-    let _ = agent.fetch_root_key().await;
-    agent
-}
 
 #[cfg(not(target_arch = "wasm32"))]
 async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -36,12 +36,9 @@ pub struct SonicAdapter;
 
 #[cfg(not(target_arch = "wasm32"))]
 async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
-    let router_id = match std::env::var("SONIC_ROUTER") {
-        Ok(v) => match Principal::from_text(v) {
-            Ok(p) => p,
-            Err(_) => return Vec::new(),
-        },
-        Err(_) => return Vec::new(),
+    let router_id = match crate::utils::env_principal("SONIC_ROUTER") {
+        Some(p) => p,
+        None => return Vec::new(),
     };
     let agent = get_agent().await;
     let arg = Encode!(&principal).unwrap();
@@ -109,12 +106,9 @@ async fn fetch_positions_impl(_principal: Principal) -> Vec<Holding> {
 #[cfg(all(feature = "claim", not(target_arch = "wasm32")))]
 async fn claim_impl(principal: Principal) -> Result<u64, String> {
     use crate::{cache, ledger_fetcher::LEDGERS};
-    let router_id = match std::env::var("SONIC_ROUTER") {
-        Ok(v) => match Principal::from_text(v) {
-            Ok(p) => p,
-            Err(_) => return Err("router".into()),
-        },
-        Err(_) => return Err("router".into()),
+    let router_id = match crate::utils::env_principal("SONIC_ROUTER") {
+        Some(p) => p,
+        None => return Err("router".into()),
     };
     let ledger = LEDGERS.first().cloned().ok_or("ledger")?;
     let agent = get_agent().await;

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -88,8 +88,6 @@ async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
     holdings
 }
 
-
-
 #[cfg(target_arch = "wasm32")]
 async fn fetch_positions_impl(_principal: Principal) -> Vec<Holding> {
     Vec::new()

--- a/src/aggregator/src/dex/dex_sonic.rs
+++ b/src/aggregator/src/dex/dex_sonic.rs
@@ -1,9 +1,9 @@
 use super::{DexAdapter, RewardInfo};
+use crate::lp_cache;
 use async_trait::async_trait;
 use bx_core::Holding;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
 use serde::Deserialize;
-use crate::lp_cache;
 
 #[derive(CandidType, Deserialize, Clone)]
 struct Token {
@@ -84,7 +84,8 @@ async fn fetch_positions_impl(principal: Principal) -> Vec<Holding> {
             }
         }
         temp
-    }).await;
+    })
+    .await;
     holdings
 }
 
@@ -138,6 +139,7 @@ fn now() -> u64 {
         .unwrap()
         .as_nanos() as u64
 }
+#[cfg(all(feature = "claim", target_arch = "wasm32"))]
 fn now() -> u64 {
     ic_cdk::api::time()
 }
@@ -187,8 +189,8 @@ impl DexAdapter for SonicAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck_macros::quickcheck;
     use candid::Principal;
+    use quickcheck_macros::quickcheck;
 
     #[tokio::test]
     async fn empty_without_env() {

--- a/src/aggregator/src/dex_fetchers.rs
+++ b/src/aggregator/src/dex_fetchers.rs
@@ -2,10 +2,8 @@ use crate::dex::dex_icpswap::IcpswapAdapter;
 use crate::dex::dex_infinity::InfinityAdapter;
 use crate::dex::dex_sonic::SonicAdapter;
 use crate::dex::DexAdapter;
-use once_cell::sync::Lazy;
 use bx_core::Holding;
 use candid::Principal;
-use futures::future::join_all;
 
 #[cfg(target_arch = "wasm32")]
 async fn sleep_ms(_: u64) {}

--- a/src/aggregator/src/dex_fetchers.rs
+++ b/src/aggregator/src/dex_fetchers.rs
@@ -7,15 +7,16 @@ use candid::Principal;
 use futures::future::join_all;
 
 #[cfg(target_arch = "wasm32")]
-async fn sleep_ms(_: u64) {}
+async fn pause() {}
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn sleep_ms(ms: u64) {
-    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+async fn pause() {
+    tokio::task::yield_now().await;
 }
 
 pub async fn fetch(principal: Principal) -> Vec<Holding> {
-    sleep_ms(10).await;
+    // allow other tasks to start before launching adapter queries
+    pause().await;
     let adapters: Vec<Box<dyn DexAdapter>> = vec![
         Box::new(IcpswapAdapter),
         Box::new(SonicAdapter),

--- a/src/aggregator/src/ledger_fetcher.rs
+++ b/src/aggregator/src/ledger_fetcher.rs
@@ -1,14 +1,22 @@
+#[cfg(not(target_arch = "wasm32"))]
 use crate::utils::format_amount;
 use bx_core::Holding;
-#[cfg(any(not(test), feature = "live-test"))]
+#[cfg(not(target_arch = "wasm32"))]
+use candid::Nat;
+use candid::Principal;
+#[cfg(all(any(not(test), feature = "live-test"), not(target_arch = "wasm32")))]
 use candid::{Decode, Encode};
-use candid::{Nat, Principal};
+#[cfg(not(target_arch = "wasm32"))]
 use dashmap::DashMap;
+#[cfg(not(target_arch = "wasm32"))]
 use futures::future::join_all;
+#[cfg(not(target_arch = "wasm32"))]
 use num_traits::cast::ToPrimitive;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
+#[cfg(not(target_arch = "wasm32"))]
 use sha2::{Digest, Sha256};
+#[cfg(not(target_arch = "wasm32"))]
 use std::future::Future;
 
 // Metadata for each ledger is cached with an expiry and a stable hash.
@@ -38,6 +46,7 @@ fn now() -> u64 {
     *TEST_NOW.lock().unwrap()
 }
 #[cfg(target_arch = "wasm32")]
+#[allow(dead_code)]
 fn now() -> u64 {
     ic_cdk::api::time()
 }
@@ -69,8 +78,10 @@ pub static LEDGERS: Lazy<Vec<Principal>> = Lazy::new(|| {
 });
 
 /// Duration that cached metadata remains valid (24h, in nanoseconds)
+#[cfg(not(target_arch = "wasm32"))]
 const META_TTL_NS: u64 = 86_400_000_000_000;
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 struct Meta {
     symbol: String,
@@ -79,6 +90,7 @@ struct Meta {
     hash: [u8; 32],
     expires: u64,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static META_CACHE: Lazy<DashMap<Principal, Meta>> = Lazy::new(DashMap::new);
 
 #[cfg(all(any(not(test), feature = "live-test"), not(target_arch = "wasm32")))]

--- a/src/aggregator/src/ledger_fetcher.rs
+++ b/src/aggregator/src/ledger_fetcher.rs
@@ -1,5 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use crate::utils::format_amount;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::utils::DAY_NS;
 use bx_core::Holding;
 #[cfg(not(target_arch = "wasm32"))]
 use candid::Nat;
@@ -77,9 +79,9 @@ pub static LEDGERS: Lazy<Vec<Principal>> = Lazy::new(|| {
         .collect()
 });
 
-/// Duration that cached metadata remains valid (24h, in nanoseconds)
+/// Duration that cached metadata remains valid (24h)
 #[cfg(not(target_arch = "wasm32"))]
-const META_TTL_NS: u64 = 86_400_000_000_000;
+const META_TTL_NS: u64 = DAY_NS;
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]

--- a/src/aggregator/src/ledger_fetcher.rs
+++ b/src/aggregator/src/ledger_fetcher.rs
@@ -1,3 +1,4 @@
+use crate::utils::format_amount;
 use bx_core::Holding;
 #[cfg(any(not(test), feature = "live-test"))]
 use candid::{Decode, Encode};
@@ -315,23 +316,6 @@ async fn fetch_metadata(
         },
     );
     Ok((symbol, decimals, fee))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn format_amount(nat: Nat, decimals: u8) -> String {
-    use num_bigint::BigUint;
-    use num_integer::Integer;
-    let div = BigUint::from(10u32).pow(decimals as u32);
-    let (q, r) = nat.0.div_rem(&div);
-    let mut frac = r.to_str_radix(10);
-    while frac.len() < decimals as usize {
-        frac.insert(0, '0');
-    }
-    if decimals == 0 {
-        q.to_str_radix(10)
-    } else {
-        format!("{}.{frac}", q.to_str_radix(10))
-    }
 }
 
 #[cfg(all(test, not(feature = "live-test"), not(target_arch = "wasm32")))]

--- a/src/aggregator/src/ledger_fetcher.rs
+++ b/src/aggregator/src/ledger_fetcher.rs
@@ -132,13 +132,9 @@ where
     unreachable!()
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 #[cfg(all(any(not(test), feature = "live-test"), not(target_arch = "wasm32")))]
 async fn get_agent() -> Agent {
-    let url = std::env::var("LEDGER_URL").unwrap_or_else(|_| "http://localhost:4943".to_string());
-    let agent = Agent::builder().with_url(url).build().unwrap();
-    let _ = agent.fetch_root_key().await;
-    agent
+    crate::utils::get_agent().await
 }
 
 #[cfg(all(test, not(feature = "live-test"), not(target_arch = "wasm32")))]

--- a/src/aggregator/src/ledger_fetcher.rs
+++ b/src/aggregator/src/ledger_fetcher.rs
@@ -36,10 +36,7 @@ use std::sync::Mutex;
 
 #[cfg(all(any(not(test), feature = "live-test"), not(target_arch = "wasm32")))]
 fn now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64
+    crate::utils::now()
 }
 #[cfg(all(test, not(feature = "live-test"), not(target_arch = "wasm32")))]
 static TEST_NOW: Lazy<Mutex<u64>> = Lazy::new(|| Mutex::new(0));
@@ -50,7 +47,7 @@ fn now() -> u64 {
 #[cfg(target_arch = "wasm32")]
 #[allow(dead_code)]
 fn now() -> u64 {
-    ic_cdk::api::time()
+    crate::utils::now()
 }
 
 #[derive(Deserialize)]

--- a/src/aggregator/src/lib.rs
+++ b/src/aggregator/src/lib.rs
@@ -40,10 +40,16 @@ pub async fn get_holdings(principal: Principal) -> Vec<Holding> {
         }
     }
 
+    let (ledger, neuron, dex) = futures::join!(
+        ledger_fetcher::fetch(principal),
+        neuron_fetcher::fetch(principal),
+        dex_fetchers::fetch(principal)
+    );
+
     let mut holdings = Vec::new();
-    holdings.extend(ledger_fetcher::fetch(principal).await);
-    holdings.extend(neuron_fetcher::fetch(principal).await);
-    holdings.extend(dex_fetchers::fetch(principal).await);
+    holdings.extend(ledger);
+    holdings.extend(neuron);
+    holdings.extend(dex);
 
     {
         cache::get().insert(principal, (holdings.clone(), now));

--- a/src/aggregator/src/lib.rs
+++ b/src/aggregator/src/lib.rs
@@ -2,9 +2,9 @@ pub mod cache;
 pub mod dex;
 pub mod dex_fetchers;
 pub mod ledger_fetcher;
+pub mod lp_cache;
 pub mod neuron_fetcher;
 pub mod pool_registry;
-pub mod lp_cache;
 
 use bx_core::Holding;
 use candid::Principal;
@@ -69,7 +69,10 @@ pub async fn get_holdings(principal: Principal) -> Vec<Holding> {
 
 #[cfg(feature = "claim")]
 pub async fn claim_all_rewards(principal: Principal) -> Vec<u64> {
-    use dex::{dex_icpswap::IcpswapAdapter, dex_sonic::SonicAdapter, dex_infinity::InfinityAdapter, DexAdapter};
+    use dex::{
+        dex_icpswap::IcpswapAdapter, dex_infinity::InfinityAdapter, dex_sonic::SonicAdapter,
+        DexAdapter,
+    };
     let adapters: Vec<Box<dyn DexAdapter>> = vec![
         Box::new(IcpswapAdapter),
         Box::new(SonicAdapter),

--- a/src/aggregator/src/lib.rs
+++ b/src/aggregator/src/lib.rs
@@ -5,22 +5,11 @@ pub mod ledger_fetcher;
 pub mod lp_cache;
 pub mod neuron_fetcher;
 pub mod pool_registry;
+pub mod utils;
 
+use crate::utils::now;
 use bx_core::Holding;
 use candid::Principal;
-
-#[cfg(target_arch = "wasm32")]
-fn now() -> u64 {
-    ic_cdk::api::time()
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64
-}
 
 #[cfg(target_arch = "wasm32")]
 fn instructions() -> u64 {

--- a/src/aggregator/src/lp_cache.rs
+++ b/src/aggregator/src/lp_cache.rs
@@ -1,4 +1,4 @@
-use crate::utils::now;
+use crate::utils::{now, WEEK_NS};
 use bx_core::Holding;
 use candid::Principal;
 use dashmap::DashMap;
@@ -13,7 +13,7 @@ struct Entry {
 
 static CACHE: Lazy<DashMap<(Principal, String), Entry>> = Lazy::new(DashMap::new);
 
-const STALE_NS: u64 = 604_800_000_000_000; // one week
+const STALE_NS: u64 = WEEK_NS; // one week
 
 pub async fn get_or_fetch<F, Fut>(
     principal: Principal,

--- a/src/aggregator/src/lp_cache.rs
+++ b/src/aggregator/src/lp_cache.rs
@@ -1,3 +1,4 @@
+use crate::utils::now;
 use bx_core::Holding;
 use candid::Principal;
 use dashmap::DashMap;
@@ -13,19 +14,6 @@ struct Entry {
 static CACHE: Lazy<DashMap<(Principal, String), Entry>> = Lazy::new(DashMap::new);
 
 const STALE_NS: u64 = 604_800_000_000_000; // one week
-
-#[cfg(not(target_arch = "wasm32"))]
-fn now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64
-}
-
-#[cfg(target_arch = "wasm32")]
-fn now() -> u64 {
-    ic_cdk::api::time()
-}
 
 pub async fn get_or_fetch<F, Fut>(
     principal: Principal,

--- a/src/aggregator/src/lp_cache.rs
+++ b/src/aggregator/src/lp_cache.rs
@@ -31,12 +31,13 @@ where
         }
     }
     let data = fetch().await;
+    let ts = now();
     CACHE.insert(
         (principal, pool.to_string()),
         Entry {
             data: data.clone(),
             height,
-            ts: now(),
+            ts,
         },
     );
     data

--- a/src/aggregator/src/lp_cache.rs
+++ b/src/aggregator/src/lp_cache.rs
@@ -56,6 +56,18 @@ pub fn schedule_eviction() {
     });
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub fn schedule_eviction() {
+    use std::time::Duration;
+    tokio::spawn(async {
+        let mut timer = tokio::time::interval(Duration::from_secs(crate::utils::WEEK_SECS));
+        loop {
+            timer.tick().await;
+            evict_stale();
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/aggregator/src/lp_cache.rs
+++ b/src/aggregator/src/lp_cache.rs
@@ -51,7 +51,7 @@ pub fn evict_stale() {
 #[cfg(target_arch = "wasm32")]
 pub fn schedule_eviction() {
     use std::time::Duration;
-    ic_cdk_timers::set_timer_interval(Duration::from_secs(604_800), || {
+    ic_cdk_timers::set_timer_interval(Duration::from_secs(crate::utils::DAY_SECS * 7), || {
         evict_stale();
     });
 }

--- a/src/aggregator/src/lp_cache.rs
+++ b/src/aggregator/src/lp_cache.rs
@@ -51,7 +51,7 @@ pub fn evict_stale() {
 #[cfg(target_arch = "wasm32")]
 pub fn schedule_eviction() {
     use std::time::Duration;
-    ic_cdk_timers::set_timer_interval(Duration::from_secs(crate::utils::DAY_SECS * 7), || {
+    ic_cdk_timers::set_timer_interval(Duration::from_secs(crate::utils::WEEK_SECS), || {
         evict_stale();
     });
 }

--- a/src/aggregator/src/lp_cache.rs
+++ b/src/aggregator/src/lp_cache.rs
@@ -22,7 +22,7 @@ fn now() -> u64 {
         .as_nanos() as u64
 }
 
-#[cfg(target_arch = "wasm32" )]
+#[cfg(target_arch = "wasm32")]
 fn now() -> u64 {
     ic_cdk::api::time()
 }
@@ -81,21 +81,33 @@ mod tests {
         let h1 = 1u64;
         let v1 = get_or_fetch(principal, pool, h1, || async {
             CALLS.fetch_add(1, Ordering::SeqCst);
-            vec![Holding { source: "x".into(), token: "t".into(), amount: "1".into(), status: "lp_escrow".into() }]
-        }).await;
+            vec![Holding {
+                source: "x".into(),
+                token: "t".into(),
+                amount: "1".into(),
+                status: "lp_escrow".into(),
+            }]
+        })
+        .await;
         assert_eq!(CALLS.load(Ordering::SeqCst), 1);
         let v2 = get_or_fetch(principal, pool, h1, || async {
             CALLS.fetch_add(1, Ordering::SeqCst);
             vec![]
-        }).await;
+        })
+        .await;
         assert_eq!(CALLS.load(Ordering::SeqCst), 1);
         assert_eq!(v2, v1);
         let v3 = get_or_fetch(principal, pool, h1 + 1, || async {
             CALLS.fetch_add(1, Ordering::SeqCst);
-            vec![Holding { source: "x".into(), token: "t".into(), amount: "2".into(), status: "lp_escrow".into() }]
-        }).await;
+            vec![Holding {
+                source: "x".into(),
+                token: "t".into(),
+                amount: "2".into(),
+                status: "lp_escrow".into(),
+            }]
+        })
+        .await;
         assert_eq!(CALLS.load(Ordering::SeqCst), 2);
         assert_eq!(v3[0].amount, "2");
     }
 }
-

--- a/src/aggregator/src/pool_registry.rs
+++ b/src/aggregator/src/pool_registry.rs
@@ -30,8 +30,9 @@ pub fn list() -> Vec<PoolMeta> {
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn refresh() {
     let path = std::env::var("POOLS_FILE").unwrap_or_else(|_| "data/pools.toml".into());
-    if let Ok(content) = tokio::fs::read_to_string(&path).await {
-        load_content(&content);
+    match tokio::fs::read_to_string(&path).await {
+        Ok(content) => load_content(&content),
+        Err(e) => eprintln!("pool registry refresh failed: {e}"),
     }
 }
 

--- a/src/aggregator/src/pool_registry.rs
+++ b/src/aggregator/src/pool_registry.rs
@@ -38,7 +38,10 @@ pub async fn refresh() {
 
 #[cfg(target_arch = "wasm32")]
 pub async fn refresh() {
-    load_content(include_str!("../../../data/pools.toml"));
+    load_content(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../data/pools.toml"
+    )));
 }
 
 fn load_content(content: &str) {

--- a/src/aggregator/src/pool_registry.rs
+++ b/src/aggregator/src/pool_registry.rs
@@ -37,7 +37,7 @@ pub async fn refresh() {
 
 #[cfg(target_arch = "wasm32")]
 pub async fn refresh() {
-    load_content(include_str!("../../data/pools.toml"));
+    load_content(include_str!("../../../data/pools.toml"));
 }
 
 fn load_content(content: &str) {

--- a/src/aggregator/src/pool_registry.rs
+++ b/src/aggregator/src/pool_registry.rs
@@ -62,6 +62,18 @@ pub fn schedule_refresh() {
     });
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub fn schedule_refresh() {
+    use std::time::Duration;
+    tokio::spawn(async {
+        let mut timer = tokio::time::interval(Duration::from_secs(crate::utils::DAY_SECS));
+        loop {
+            timer.tick().await;
+            refresh().await;
+        }
+    });
+}
+
 pub fn graphql(_query: String) -> String {
     let data = list();
     serde_json::json!({"data": {"pools": data}}).to_string()

--- a/src/aggregator/src/pool_registry.rs
+++ b/src/aggregator/src/pool_registry.rs
@@ -1,6 +1,6 @@
+use candid::CandidType;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use candid::CandidType;
 use std::collections::HashMap;
 use std::sync::RwLock;
 
@@ -20,7 +20,8 @@ struct PoolsFile {
     pool: Vec<PoolMeta>,
 }
 
-static REGISTRY: Lazy<RwLock<HashMap<String, PoolMeta>>> = Lazy::new(|| RwLock::new(HashMap::new()));
+static REGISTRY: Lazy<RwLock<HashMap<String, PoolMeta>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
 
 pub fn list() -> Vec<PoolMeta> {
     REGISTRY.read().unwrap().values().cloned().collect()

--- a/src/aggregator/src/pool_registry.rs
+++ b/src/aggregator/src/pool_registry.rs
@@ -54,7 +54,7 @@ fn load_content(content: &str) {
 #[cfg(target_arch = "wasm32")]
 pub fn schedule_refresh() {
     use std::time::Duration;
-    ic_cdk_timers::set_timer_interval(Duration::from_secs(86_400), || {
+    ic_cdk_timers::set_timer_interval(Duration::from_secs(crate::utils::DAY_SECS), || {
         ic_cdk::spawn(async { refresh().await });
     });
 }

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -1,6 +1,7 @@
 use candid::Nat;
 
-/// Nanoseconds in one day and one week
+/// Common time constants in nanoseconds
+pub const MINUTE_NS: u64 = 60_000_000_000;
 pub const DAY_NS: u64 = 86_400_000_000_000;
 pub const WEEK_NS: u64 = DAY_NS * 7;
 pub const DAY_SECS: u64 = 86_400;

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -1,5 +1,10 @@
 use candid::Nat;
 
+/// Nanoseconds in one day and one week
+pub const DAY_NS: u64 = 86_400_000_000_000;
+pub const WEEK_NS: u64 = DAY_NS * 7;
+pub const DAY_SECS: u64 = 86_400;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub fn now() -> u64 {
     std::time::SystemTime::now()

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -42,3 +42,10 @@ pub async fn get_agent() -> ic_agent::Agent {
     let _ = agent.fetch_root_key().await;
     agent
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn env_principal(name: &str) -> Option<candid::Principal> {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| candid::Principal::from_text(v).ok())
+}

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -71,3 +71,19 @@ pub fn env_principal(name: &str) -> Option<candid::Principal> {
         Err(_) => None,
     }
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn dex_block_height(
+    agent: &ic_agent::Agent,
+    cid: candid::Principal,
+) -> Option<u64> {
+    use candid::{Decode, Encode};
+    let arg = Encode!().unwrap();
+    let bytes = agent
+        .query(&cid, "block_height")
+        .with_arg(arg)
+        .call()
+        .await
+        .ok()?;
+    Decode!(&bytes, u64).ok()
+}

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -62,8 +62,13 @@ pub async fn get_agent() -> ic_agent::Agent {
         return a.clone();
     }
     let url = std::env::var("LEDGER_URL").unwrap_or_else(|_| "http://localhost:4943".into());
-    let agent = ic_agent::Agent::builder().with_url(url).build().unwrap();
-    let _ = agent.fetch_root_key().await;
+    let agent = ic_agent::Agent::builder()
+        .with_url(url)
+        .build()
+        .expect("failed to build agent");
+    if let Err(e) = agent.fetch_root_key().await {
+        eprintln!("failed to fetch root key: {e}");
+    }
     let _ = AGENT.set(agent.clone());
     agent
 }

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -7,6 +7,8 @@ pub const MINUTE_NS: u64 = 60_000_000_000;
 pub const DAY_NS: u64 = 86_400_000_000_000;
 pub const WEEK_NS: u64 = DAY_NS * 7;
 pub const DAY_SECS: u64 = 86_400;
+/// Seconds in one week
+pub const WEEK_SECS: u64 = DAY_SECS * 7;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn now() -> u64 {

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -60,7 +60,14 @@ pub async fn get_agent() -> ic_agent::Agent {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn env_principal(name: &str) -> Option<candid::Principal> {
-    std::env::var(name)
-        .ok()
-        .and_then(|v| candid::Principal::from_text(v).ok())
+    match std::env::var(name) {
+        Ok(v) => match candid::Principal::from_text(&v) {
+            Ok(p) => Some(p),
+            Err(e) => {
+                eprintln!("{name} is not a valid principal: {e}");
+                None
+            }
+        },
+        Err(_) => None,
+    }
 }

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -73,10 +73,7 @@ pub fn env_principal(name: &str) -> Option<candid::Principal> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn dex_block_height(
-    agent: &ic_agent::Agent,
-    cid: candid::Principal,
-) -> Option<u64> {
+pub async fn dex_block_height(agent: &ic_agent::Agent, cid: candid::Principal) -> Option<u64> {
     use candid::{Decode, Encode};
     let arg = Encode!().unwrap();
     let bytes = agent

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -1,0 +1,36 @@
+use candid::Nat;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn now() -> u64 {
+    ic_cdk::api::time()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn format_amount(n: Nat, decimals: u8) -> String {
+    use num_bigint::BigUint;
+    use num_integer::Integer;
+    let div = BigUint::from(10u32).pow(decimals as u32);
+    let (q, r) = n.0.div_rem(&div);
+    let mut frac = r.to_str_radix(10);
+    while frac.len() < decimals as usize {
+        frac.insert(0, '0');
+    }
+    if decimals == 0 {
+        q.to_str_radix(10)
+    } else {
+        format!("{}.{frac}", q.to_str_radix(10))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn format_amount(n: Nat, _decimals: u8) -> String {
+    n.0.to_string()
+}

--- a/src/aggregator/src/utils.rs
+++ b/src/aggregator/src/utils.rs
@@ -34,3 +34,11 @@ pub fn format_amount(n: Nat, decimals: u8) -> String {
 pub fn format_amount(n: Nat, _decimals: u8) -> String {
     n.0.to_string()
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn get_agent() -> ic_agent::Agent {
+    let url = std::env::var("LEDGER_URL").unwrap_or_else(|_| "http://localhost:4943".into());
+    let agent = ic_agent::Agent::builder().with_url(url).build().unwrap();
+    let _ = agent.fetch_root_key().await;
+    agent
+}

--- a/src/aggregator_canister/src/lib.rs
+++ b/src/aggregator_canister/src/lib.rs
@@ -1,5 +1,5 @@
-pub use aggregator::*;
 use aggregator::pool_registry;
+pub use aggregator::*;
 
 #[ic_cdk_macros::init]
 fn init() {

--- a/src/aggregator_canister/src/lib.rs
+++ b/src/aggregator_canister/src/lib.rs
@@ -3,9 +3,9 @@ pub use aggregator::*;
 #[ic_cdk_macros::init]
 fn init() {
     ic_cdk::spawn(async { aggregator::pool_registry::refresh().await });
+    aggregator::pool_registry::schedule_refresh();
     #[cfg(target_arch = "wasm32")]
     {
-        aggregator::pool_registry::schedule_refresh();
         aggregator::lp_cache::schedule_eviction();
     }
 }

--- a/src/aggregator_canister/src/lib.rs
+++ b/src/aggregator_canister/src/lib.rs
@@ -1,12 +1,11 @@
-use aggregator::pool_registry;
 pub use aggregator::*;
 
 #[ic_cdk_macros::init]
 fn init() {
-    ic_cdk::spawn(async { pool_registry::refresh().await });
+    ic_cdk::spawn(async { aggregator::pool_registry::refresh().await });
     #[cfg(target_arch = "wasm32")]
     {
-        pool_registry::schedule_refresh();
+        aggregator::pool_registry::schedule_refresh();
         aggregator::lp_cache::schedule_eviction();
     }
 }

--- a/src/aggregator_canister/src/lib.rs
+++ b/src/aggregator_canister/src/lib.rs
@@ -4,8 +4,5 @@ pub use aggregator::*;
 fn init() {
     ic_cdk::spawn(async { aggregator::pool_registry::refresh().await });
     aggregator::pool_registry::schedule_refresh();
-    #[cfg(target_arch = "wasm32")]
-    {
-        aggregator::lp_cache::schedule_eviction();
-    }
+    aggregator::lp_cache::schedule_eviction();
 }

--- a/src/mock_icpswap_canister/src/lib.rs
+++ b/src/mock_icpswap_canister/src/lib.rs
@@ -24,7 +24,8 @@ struct PoolData {
     token0: Token,
     token1: Token,
     fee: u64,
-    tickSpacing: i32,
+    #[serde(rename = "tickSpacing")]
+    tick_spacing: i32,
     canister_id: Principal,
 }
 
@@ -69,7 +70,7 @@ fn get_pools() -> Vec<PoolData> {
             standard: "ICRC1".to_string(),
         },
         fee: 0,
-        tickSpacing: 1,
+        tick_spacing: 1,
         canister_id: ic_cdk::api::id(),
     }]
 }

--- a/src/mock_icpswap_canister/src/lib.rs
+++ b/src/mock_icpswap_canister/src/lib.rs
@@ -1,9 +1,9 @@
+use candid::Nat;
 use candid::{CandidType, Principal};
 use ic_cdk_macros::{query, update};
 use once_cell::sync::Lazy;
-use std::sync::Mutex;
 use serde::Deserialize;
-use candid::Nat;
+use std::sync::Mutex;
 
 #[derive(CandidType, Deserialize, Clone)]
 struct UserPositionInfoWithTokenAmount {
@@ -90,7 +90,9 @@ fn advance_block() {
 #[candid::candid_method(update)]
 #[update]
 async fn claim(p: Principal, ledger: Principal) -> u64 {
-    let _ : () = ic_cdk::call(ledger, "credit", (p, Nat::from(50_000_000u64))).await.unwrap();
+    let _: () = ic_cdk::call(ledger, "credit", (p, Nat::from(50_000_000u64)))
+        .await
+        .unwrap();
     10_000
 }
 

--- a/src/mock_infinity_canister/src/lib.rs
+++ b/src/mock_infinity_canister/src/lib.rs
@@ -1,8 +1,8 @@
 use candid::{CandidType, Nat, Principal};
 use ic_cdk_macros::{query, update};
 use once_cell::sync::Lazy;
-use std::sync::Mutex;
 use serde::Deserialize;
+use std::sync::Mutex;
 
 #[derive(CandidType, Deserialize, Clone)]
 struct Position {

--- a/src/mock_ledger_canister/src/lib.rs
+++ b/src/mock_ledger_canister/src/lib.rs
@@ -1,8 +1,8 @@
 use candid::{CandidType, Nat, Principal};
 use ic_cdk_macros::{query, update};
-use serde::Deserialize;
 use num_traits::cast::ToPrimitive;
 use once_cell::sync::Lazy;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Mutex;
 

--- a/src/mock_sonic_canister/src/lib.rs
+++ b/src/mock_sonic_canister/src/lib.rs
@@ -1,9 +1,9 @@
+use candid::Nat;
 use candid::{CandidType, Principal};
 use ic_cdk_macros::{query, update};
 use once_cell::sync::Lazy;
-use std::sync::Mutex;
-use candid::Nat;
 use serde::Deserialize;
+use std::sync::Mutex;
 
 #[derive(CandidType, Deserialize, Clone)]
 struct Token {
@@ -83,7 +83,9 @@ fn advance_block() {
 #[candid::candid_method(update)]
 #[update]
 async fn claim(p: Principal, ledger: Principal) -> u64 {
-    let _ : () = ic_cdk::call(ledger, "credit", (p, Nat::from(25_000_000u64))).await.unwrap();
+    let _: () = ic_cdk::call(ledger, "credit", (p, Nat::from(25_000_000u64)))
+        .await
+        .unwrap();
     5_000
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,8 +1,6 @@
 #[cfg(test)]
 mod tests {
     use blockxpand_icp::{get_holdings, Holding};
-    #[cfg(feature = "claim")]
-    use candid::Nat;
     use candid::{Decode, Encode, Principal};
     use ic_agent::{identity::AnonymousIdentity, Agent};
     use std::io::Write;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
     use blockxpand_icp::{get_holdings, Holding};
-    use candid::{Decode, Encode, Principal};
     #[cfg(feature = "claim")]
     use candid::Nat;
+    use candid::{Decode, Encode, Principal};
     use ic_agent::{identity::AnonymousIdentity, Agent};
     use std::io::Write;
     use std::path::Path;


### PR DESCRIPTION
## Summary
- remove duplicated entry for `mock_sonic_canister` from `Cargo.lock`
- adjust `now()` in `dex_sonic` for feature gating
- drop unused imports in `dex_fetchers`
- apply `rustfmt` cleanup across the repo

## Testing
- `cargo clippy --quiet -- -D warnings`
- `cargo test --quiet`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_686a50bc73a4833398edbc7a985de692